### PR TITLE
Update primary yellow color to red

### DIFF
--- a/source/00-config/vars/palette.css
+++ b/source/00-config/vars/palette.css
@@ -7,8 +7,8 @@
   --brand-blue-dark-1: #151A26;
   --brand-blue-dark-2: #040A19;
 
-  --brand-yellow-base: #FFC125;
-  --brand-yellow-light: #FFE4A0;
+  --brand-yellow-base: #e31c3d;
+  --brand-yellow-light: #f9dede;
 
   --brand-ocean-blue-base: #1dc2ae;
   --brand-ocean-blue-light: #29e1cb;


### PR DESCRIPTION
Updates the primary yellow brand color (`--brand-yellow-base`) to red (`#e31c3d`) and the light yellow (`--brand-yellow-light`) to a light red (`#f9dede`) in `source/00-config/vars/palette.css`.

This change propagates to all accent colors, text links, and focus states throughout the site.

Closes #3

Generated with [Claude Code](https://claude.ai/code)